### PR TITLE
Configure jest-preview to support css and images

### DIFF
--- a/podcast-player/jest.config.js
+++ b/podcast-player/jest.config.js
@@ -1,0 +1,43 @@
+module.exports = {
+  roots: ["<rootDir>/src"],
+  collectCoverageFrom: ["src/**/*.{js,jsx,ts,tsx}", "!src/**/*.d.ts"],
+  setupFiles: ["react-app-polyfill/jsdom"],
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests.js"],
+  testMatch: [
+    "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
+    "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}",
+  ],
+  testEnvironment: "jsdom",
+  testRunner: "jest-circus/runner.js",
+  transform: {
+    "^.+\\.(js|jsx|mjs|cjs|ts|tsx)$":
+      "react-scripts/config/jest/babelTransform.js",
+    "^.+\\.(css|scss|sass)$": "jest-preview/transforms/css",
+    "^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)":
+      "jest-preview/transforms/fileCRA",
+  },
+  transformIgnorePatterns: [
+    "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",
+  ],
+  modulePaths: [],
+  moduleNameMapper: {
+    "^react-native$": "react-native-web",
+  },
+  moduleFileExtensions: [
+    "web.js",
+    "js",
+    "web.ts",
+    "ts",
+    "web.tsx",
+    "tsx",
+    "json",
+    "web.jsx",
+    "jsx",
+    "node",
+  ],
+  watchPlugins: [
+    "jest-watch-typeahead/filename",
+    "jest-watch-typeahead/testname",
+  ],
+  resetMocks: true,
+};

--- a/podcast-player/package.json
+++ b/podcast-player/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "node scripts/test.js",
     "eject": "react-scripts eject",
     "jest-preview": "jest-preview"
   },

--- a/podcast-player/scripts/test.js
+++ b/podcast-player/scripts/test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Do this as the first thing so that any code reading it knows the right env.
+process.env.BABEL_ENV = 'test';
+process.env.NODE_ENV = 'test';
+process.env.PUBLIC_URL = '';
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
+// Ensure environment variables are read.
+require('react-scripts/config/env');
+
+
+const jest = require('jest');
+const execSync = require('child_process').execSync;
+let argv = process.argv.slice(2);
+
+function isInGitRepository() {
+  try {
+    execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function isInMercurialRepository() {
+  try {
+    execSync('hg --cwd . root', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+// Watch unless on CI or explicitly running all tests
+if (
+  !process.env.CI &&
+  argv.indexOf('--watchAll') === -1 &&
+  argv.indexOf('--watchAll=false') === -1
+) {
+  // https://github.com/facebook/create-react-app/issues/5210
+  const hasSourceControl = isInGitRepository() || isInMercurialRepository();
+  argv.push(hasSourceControl ? '--watch' : '--watchAll');
+}
+
+
+jest.run(argv);

--- a/podcast-player/src/setupTests.js
+++ b/podcast-player/src/setupTests.js
@@ -3,3 +3,10 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { jestPreviewConfigure } from 'jest-preview';
+import './index.css';
+
+jestPreviewConfigure({
+  // Opt-in to automatic mode to preview failed test case automatically
+  autoPreview: true,
+});


### PR DESCRIPTION
## Features

- [x] Configure jest-preview to support css and images by running: 

```bash
npx jest-preview config-cra
```
(https://www.jest-preview.com/blog/first-class-support-cra)

- [x] Opt-in to [Automatic Mode](https://www.jest-preview.com/blog/automatic-mode).

## Screenshots
Before 
<img width="945" alt="jest preview dashboard without any styling" src="https://user-images.githubusercontent.com/8603085/174064693-423c4eeb-12b1-4506-b4be-8123ce827775.png">

After
<img width="1438" alt="jest preview dashboard with exact styling as real app" src="https://user-images.githubusercontent.com/8603085/174064747-5ad7c4fb-1052-471a-9879-44d6ea28cd97.png">

## Note
If the Jest Preview Dashboard doesn't update the CSS. Try clear Jest cache by `jest --clearCache`, or `npm run test -- --clearCache`